### PR TITLE
Fixed result.stderr bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+#jetbrains stuff
+.idea

--- a/index.js
+++ b/index.js
@@ -3,6 +3,14 @@ const exec = require('child-process-promise').exec;
 const path = require('path');
 const MAX_BUFFER_SIZE = 2000 * 1024;
 
+/* istanbul ignore if */
+function assertNoStdErr({stderr}){
+	if (!("string" === typeof stderr && 0 !== stderr.length))
+		return;
+	
+	throw (new Error(stderr));
+}
+
 let windowsNetworkDrive = {
 	/**
 	 * @function find
@@ -65,8 +73,6 @@ let windowsNetworkDrive = {
 				 */
 				for (let currentDriveLetter in networkDrives)
 				{
-					let currentDrivePath;
-
 					/**
 					 * There is not an easy way to test this
 					 */
@@ -75,7 +81,7 @@ let windowsNetworkDrive = {
 					{
 						continue;
 					}
-					currentDrivePath = networkDrives[currentDriveLetter];
+					const currentDrivePath = networkDrives[currentDriveLetter];
 
 					if (currentDrivePath === drivePath)
 					{
@@ -134,19 +140,11 @@ let windowsNetworkDrive = {
 			})
 			.then(function (result)
 			{
+				assertNoStdErr(result);
+
 				let pathList;
 				let drivePaths = {};
 				let currentPathIndex;
-
-				/**
-				 * Ignore this in code coverage because it should never happen
-				 */
-				/* istanbul ignore if */
-				if ("string" === typeof result.stderr &&
-					0 !== result.stderr.length)
-				{
-					throw (new Error(stderr));
-				}
 
 				/**
 				 * Break based on the line endings (one for each network drive)
@@ -302,19 +300,8 @@ let windowsNetworkDrive = {
 			{
 				return exec(mountCommand, { maxBuffer: MAX_BUFFER_SIZE });
 			})
-			.then(function (result)
-			{
-				/**
-				 * Ignore this in code coverage because it should never happen
-				 */
-				/* istanbul ignore if */
-				if ("string" === typeof result.stderr &&
-					0 !== result.stderr.length)
-				{
-					throw (new Error(stderr));
-				}
-			})
-
+			.then(assertNoStdErr)
+			
 			/**
 			 * Return the drive letter for this mount
 			 */
@@ -375,18 +362,7 @@ let windowsNetworkDrive = {
 					let unmountCommand = "net use " + driveLetter + ": /Delete /y";
 
 					return exec(unmountCommand, { maxBuffer: MAX_BUFFER_SIZE })
-						.then(function (result)
-						{
-							/**
-							 * Ignore this in code coverage because it should never happen
-							 */
-							/* istanbul ignore if */
-							if ("string" === typeof result.stderr &&
-								0 !== result.stderr.length)
-							{
-								throw (new Error(stderr));
-							}
-						});
+						.then(assertNoStdErr);
 				}
 				/**
 				 * Ignore false possitive

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "windows-network-drive",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Hi @larrybahr 

While using your lib I had an issue with the following code

```
/**
 * Ignore this in code coverage because it should never happen
 */
if ("string" === typeof result.stderr &&
	0 !== result.stderr.length)
{
	throw (new Error(stderr));
}
```

`throw (new Error(stderr));` should be `throw (new Error(result.stderr));`

So, I forked and fixed it.

Btw: One test was failing aready (mount twice test) - you should review that one.