### PR TITLE
list() return all drives

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,10 @@ $ npm test
 
 ## Contributing
 
-In lieu of a formal style guide, take care to maintain the existing coding style. Format code with VS Code. Add unit tests for any new or changed functionality. Lint and test your code.
+In lieu of a formal style guide, take care to maintain the existing coding style.
+* Format code with VS Code, using the default "Typescript and JavaScript Language Features" formatter.
+* Add unit tests for any new or changed functionality.
+* Lint and test your code.
 
 ## People
 

--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@ let networkDrive = require('windows-network-drive');
 ### find
 Finds if a path is already mounted and returns all drive letters that point to that exact path.
 ```typescript
-find(drivePath: string): Promise<string[]>
+find(drivePath: string): Promise<{status: boolean, driveLetter: string, path: string, statusMessage: string}[]>
 ```
 
 #### Examples
 
 ```javascript
  networkDrive.find("\\\\DoesExist\\Path")
- .then(function (driveLetter)
+ .then(function (result)
  {
-	 // driveLetter === ["Z"]
+	 // result === [{status: true, driveLetter: "Z", path: "\\\\DoesExist\\Path", "statusMessage": "OK"}]
  });
 
   networkDrive.find("\\\\DoesExist\\Path\\ThisFolderIsNotPartOfTheMountPath")
@@ -71,8 +71,8 @@ list(void): Promise<object>
  {
 	 /*
 		drives = {
-			"F":"\\\\DoesExist\\Path\\Files",
-			"K":"\\\\NETWORKB\\DRIVE C"
+			"F": { "status": true, "driveLetter": "F", "path": "\\\\NETWORKA\\Files", "statusMessage": "OK" },
+			"K": { "status": true, "driveLetter": "K", "path": "\\\\NETWORKB\\Files", "statusMessage": "OK" }
 		}
 	*/
  });
@@ -128,7 +128,7 @@ pathToWindowsPath(drivePath: string): Promise<string>
 #### Examples
 
 ```javascript
- networkDrive.pathToWindowsPath(//DoesExist/Path/Files)
+ networkDrive.pathToWindowsPath("//DoesExist/Path/Files")
  .then(function (windowsPath)
  {
 	 // windowsPath = \\\\DoesExist\\Path\\Files

--- a/example/write-a-file-to-a-network-drive/index.js
+++ b/example/write-a-file-to-a-network-drive/index.js
@@ -20,8 +20,8 @@ Promise.resolve()
 	{
 		if (0 < driveLetters.length)
 		{
-			console.log("The drive is already mounted. Returning the first drive (" + driveLetters[0] + ") letter because they all point to the same place.");
-			return driveLetters[0];
+			console.log("The drive is already mounted. Returning the first drive (" + driveLetters[0].driveLetter + ") letter because they all point to the same place.");
+			return driveLetters[0].driveLetter;
 		}
 		else
 		{

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,28 +1,25 @@
 declare module 'windows-network-drive' {
-  /** Finds if a path is already mounted and returns all drive letters that point to that exact path. */
-  function find(drivePath: string): Promise<{
+
+  interface DriveInfo
+  {
     /** Status of the network drive. A falsy value might indicate connectivity issues */
     status: boolean
     /** Drive letter */
     driveLetter: string
     /** Path to the network drive */
     path: string
-  }[]>;
+    /**
+     * Status string, describing the status of the network drive.
+     * This is a textual value depending on the local Windows system language.
+     */
+    statusMessage: string
+  }
+
+  /** Finds if a path is already mounted and returns all drive letters that point to that exact path. */
+  function find(drivePath: string): Promise<DriveInfo[]>;
 
   /** List all network drives and their paths. */
-  function list(): Promise<{
-    [driveLetter: string]: {
-      /** Status of the network drive. A falsy value might indicate connectivity issues */
-      status: boolean
-      /** Path to the network drive */
-      path: string
-
-      /**
-       * Status string, describing the status of the network drive.
-       * This is a textual value depending on the local Windows system language. */
-      statusString: string
-    }
-  }>;
+  function list(): Promise<{ [driveLetter: string]: DriveInfo }>;
 
   /** Mounts a network drive path and returns the new drive letter. */
   function mount(

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,17 +10,19 @@ declare module 'windows-network-drive' {
   }[]>;
 
   /** List all network drives and their paths. */
-  function list(): Promise<{ [driveLetter: string]: {
-    /** Status of the network drive. A falsy value might indicate connectivity issues */
-    status: boolean
-    /** Path to the network drive */
-    path: string
+  function list(): Promise<{
+    [driveLetter: string]: {
+      /** Status of the network drive. A falsy value might indicate connectivity issues */
+      status: boolean
+      /** Path to the network drive */
+      path: string
 
-    /**
-     * Status string, describing the status of the network drive.
-     * This is a textual value depending on the local Windows system language. */
-    statusString: string
-  } }>;
+      /**
+       * Status string, describing the status of the network drive.
+       * This is a textual value depending on the local Windows system language. */
+      statusString: string
+    }
+  }>;
 
   /** Mounts a network drive path and returns the new drive letter. */
   function mount(

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,26 @@
 declare module 'windows-network-drive' {
   /** Finds if a path is already mounted and returns all drive letters that point to that exact path. */
-  function find(drivePath: string): Promise<string[]>;
+  function find(drivePath: string): Promise<{
+    /** Status of the network drive. A falsy value might indicate connectivity issues */
+    status: boolean
+    /** Drive letter */
+    driveLetter: string
+    /** Path to the network drive */
+    path: string
+  }[]>;
 
   /** List all network drives and their paths. */
-  function list(): Promise<{ [driveLetter: string]: string }>;
+  function list(): Promise<{ [driveLetter: string]: {
+    /** Status of the network drive. A falsy value might indicate connectivity issues */
+    status: boolean
+    /** Path to the network drive */
+    path: string
+
+    /**
+     * Status string, describing the status of the network drive.
+     * This is a textual value depending on the local Windows system language. */
+    statusString: string
+  } }>;
 
   /** Mounts a network drive path and returns the new drive letter. */
   function mount(

--- a/index.js
+++ b/index.js
@@ -168,7 +168,7 @@ let windowsNetworkDrive = {
 				const lines = `${result.stdout}`
 					.replace(/^(-+)$/gm, '') // remove the "-----------------------------"-line
 					.split('\n')
-					.map((l) => l.replace(/[\r\n]/g, '')) // Trim line endings
+					.map((line) => line.trim()) // Trim line endings
 					.filter(Boolean) // Remove empty lines
 					.slice(1) // Remove the first line ("New connections...")
 					.slice(1) // Remove the table header line ("Status   Local...")

--- a/index.js
+++ b/index.js
@@ -176,34 +176,34 @@ let windowsNetworkDrive = {
 
 
 				// Fix an issue where the table rows are split in multiple lines, because of a long path:
-				for (let i = 0; i < lines.length; i++)
+				for (let lineIndex = 0; lineIndex < lines.length; lineIndex++)
 				{
-					if (lines[i][0] === ' ')
+					if (lines[lineIndex][0] === ' ')
 					{
 						// The line is a line-break of the previous line.
 						// Merge with previous:
-						const toMergeLine = lines.splice(i, 1)[0];
-						lines[i - 1] += ' ' + toMergeLine.trim();
-						i--;
+						const toMergeLine = lines.splice(lineIndex, 1)[0];
+						lines[lineIndex - 1] += ' ' + toMergeLine.trim();
+						lineIndex--;
 					}
 				}
 
 				const drivePaths = {}
-				for (let i = 0; i < lines.length; i++)
+				for (let lineIndex = 0; lineIndex < lines.length; lineIndex++)
 				{
-					const line = lines[i];
+					const line = lines[lineIndex];
 
-					const m = line.match(/^(.+) +(\w): +([^ ]+) +(.+)$/);
-					if (m)
+					const lineMatch = line.match(/^(.+) +(\w): +([^ ]+) +(.+)$/);
+					if (lineMatch)
 					{
 						/**
 						 * Examples of statusMessage:
 						 * "OK" | "Disconnected" | "Not Avail"
 						 * Note: the statusMessage might contain other status, as it depends on the Windows system language.
 						 */
-						const statusMessage = m[1].trim();
-						const driveLetter = m[2].trim().toUpperCase();
-						const path = m[3].trim();
+						const statusMessage = lineMatch[1].trim();
+						const driveLetter = lineMatch[2].trim().toUpperCase();
+						const path = lineMatch[3].trim();
 						// const network = m[4].trim();
 
 						drivePaths[driveLetter] = {

--- a/index.js
+++ b/index.js
@@ -141,11 +141,11 @@ let windowsNetworkDrive = {
 	 *    "K": { "ok": true, "path": "\\NETWORKB\DRIVE G", "statusString": "OK" }
 	 * }
 	 */
-	 list: function list()
-	 {
-		 let listPromise;
+	list: function list()
+	{
+		let listPromise;
 
-		 listPromise = Promise.resolve()
+		listPromise = Promise.resolve()
 			.then(function ()
 			{
 				if (false === windowsNetworkDrive.isWinOs())
@@ -181,22 +181,26 @@ let windowsNetworkDrive = {
 
 
 				// Fix an issue where the table rows are split in multiple lines, because of a long path:
-				for (let i = 0; i< lines.length; i++) {
-					if (lines[i][0] === ' ') {
+				for (let i = 0; i < lines.length; i++)
+				{
+					if (lines[i][0] === ' ')
+					{
 						// The line is a line-break of the previous line.
 						// Merge with previous:
 						const toMergeLine = lines.splice(i, 1)[0];
-						lines[i-1] += ' ' + toMergeLine.trim();
+						lines[i - 1] += ' ' + toMergeLine.trim();
 						i--;
 					}
 				}
 
 				const drivePaths = {}
-				for (let i = 0; i< lines.length; i++) {
+				for (let i = 0; i < lines.length; i++)
+				{
 					const line = lines[i];
 
 					const m = line.match(/^(.+) +(\w): +([^ ]+) +(.+)$/);
-					if (m) {
+					if (m)
+					{
 						/**
 						 * Examples of statusString:
 						 * "OK" | "Disconnected" | "Not Avail"
@@ -217,9 +221,9 @@ let windowsNetworkDrive = {
 				}
 				return drivePaths
 
-			 })
-		 return listPromise;
-	 },
+			})
+		return listPromise;
+	},
 
 	/**
 	 * @function mount

--- a/index.js
+++ b/index.js
@@ -32,9 +32,9 @@ let windowsNetworkDrive = {
 	 * @returns {Promise<{status: boolean, driveLetter: string, path: string, statusMessage: string}[]>} - An array of results
 	 * @description Gets the network drive letter for a path
 	 * @example
-	 * networkDrive.find("\\DoesExist\Path")
+	 * networkDrive.find("\\\\DoesExist\\Path")
 	 * // returns
-	 * ["T"]
+	 * [{status: true, driveLetter: "Z", path: "\\\\DoesExist\\Path", statusMessage: "OK"}]
 	 * @example
 	 * networkDrive.find("\\DoesNOTExist\Path")
 	 * // returns
@@ -132,8 +132,8 @@ let windowsNetworkDrive = {
 	 * networkDrive.list()
 	 * // returns
 	 * {
-	 *    "F": { "ok": true, "path": "\\NETWORKA\Files", "statusMessage": "OK" },
-	 *    "K": { "ok": true, "path": "\\NETWORKB\DRIVE G", "statusMessage": "OK" }
+	 *    "F": { "status": true, "driveLetter": "F", "path": "\\\\NETWORKA\\Files", "statusMessage": "OK" },
+	 *    "K": { "status": true, "driveLetter": "K", "path": "\\\\NETWORKB\\DRIVE G", "statusMessage": "OK" }
 	 * }
 	 */
 	list: function list()

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ let windowsNetworkDrive = {
 	 * @function find
 	 * @public
 	 * @param {string} drivePath - Drive path to search for
-	 * @returns {Promise<string[]>} - An array of drive letters that point to the drive path
+	 * @returns {Promise<{status: boolean, driveLetter: string, path: string, statusMessage: string}[]>} - An array of results
 	 * @description Gets the network drive letter for a path
 	 * @example
 	 * networkDrive.find("\\DoesExist\Path")
@@ -79,7 +79,7 @@ let windowsNetworkDrive = {
 			.then(windowsNetworkDrive.list)
 			.then(function (networkDrives)
 			{
-				let driveLetters = [];
+				const filteredDrives = [];
 
 				/**
 				 * Create the list of drives to path
@@ -99,15 +99,10 @@ let windowsNetworkDrive = {
 
 					if (currentDrive.path === drivePath)
 					{
-						driveLetters.push({
-
-							status: currentDrive.status,
-							driveLetter: currentDriveLetter,
-							path: currentDrive.path
-						});
+						filteredDrives.push(currentDrive);
 					}
 				}
-				return driveLetters;
+				return filteredDrives;
 			})
 		return findPromise;
 	},
@@ -131,14 +126,14 @@ let windowsNetworkDrive = {
 	/**
 	 * @function list
 	 * @public
-	 * @returns {Promise<Object>} - Object keys are drive letters, values are { ok: boolean, path: string }
+	 * @returns {Promise<{ status: boolean, driveLetter: string, path: string, statusMessage: string }>} - Object keys are drive letters
 	 * @description lists all network drives and paths
 	 * @example
 	 * networkDrive.list()
 	 * // returns
 	 * {
-	 *    "F": { "ok": true, "path": "\\NETWORKA\Files", "statusString": "OK" },
-	 *    "K": { "ok": true, "path": "\\NETWORKB\DRIVE G", "statusString": "OK" }
+	 *    "F": { "ok": true, "path": "\\NETWORKA\Files", "statusMessage": "OK" },
+	 *    "K": { "ok": true, "path": "\\NETWORKB\DRIVE G", "statusMessage": "OK" }
 	 * }
 	 */
 	list: function list()
@@ -202,19 +197,20 @@ let windowsNetworkDrive = {
 					if (m)
 					{
 						/**
-						 * Examples of statusString:
+						 * Examples of statusMessage:
 						 * "OK" | "Disconnected" | "Not Avail"
-						 * Note: the statusString might contain other status, as it depends on the Windows system language.
+						 * Note: the statusMessage might contain other status, as it depends on the Windows system language.
 						 */
-						const statusString = m[1].trim();
+						const statusMessage = m[1].trim();
 						const driveLetter = m[2].trim().toUpperCase();
 						const path = m[3].trim();
 						// const network = m[4].trim();
 
 						drivePaths[driveLetter] = {
-							status: statusString === 'OK',
-							statusString: statusString,
+							status: statusMessage === 'OK',
+							driveLetter: driveLetter,
 							path: path,
+							statusMessage: statusMessage,
 						};
 
 					}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
     {
       "name": "mikaello",
       "url": "https://github.com/mikaello"
+    },
+    {
+      "name": "Johan Nyman",
+      "url": "https://github.com/nytamin"
     }
   ],
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -494,31 +494,31 @@ describe('windows-network-drive', function ()
 
 
 					const driveLetters = Object.keys(driveList)
-					for (let i = 0; i < driveLetters.length; i++)
+					for (let driveLetterIndex = 0; driveLetterIndex < driveLetters.length; driveLetterIndex++)
 					{
 						/**
 						 * The drive letter should be a string of length 1, ie "Z"
 						 */
-						if (typeof driveLetters[i] !== 'string' || driveLetters[i].length !== 1)
+						if (typeof driveLetters[driveLetterIndex] !== 'string' || driveLetters[driveLetterIndex].length !== 1)
 						{
 							throw (new Error("Drive letter is not a string of length 1. driveList = " + JSON.stringify(driveList, null, '\t')));
 						}
 						/**
 						 * The drive letter should be uppercase
 						 */
-						if (driveLetters[i] !== driveLetters[i].toUpperCase())
+						if (driveLetters[driveLetterIndex] !== driveLetters[driveLetterIndex].toUpperCase())
 						{
 							throw (new Error("Drive letter is not uppercase. driveList = " + JSON.stringify(driveList, null, '\t')));
 						}
 					}
 
 					const firstResult = driveList[driveLetters[0]];
-					if (!firstResult)
+					if ('object' !== typeof firstResult)
 					{
 						throw (new Error("Bad result data. driveList = " + JSON.stringify(driveList, null, '\t')));
 					}
 
-					if (firstResult.status !== Boolean(firstResult.status))
+					if (typeof firstResult.status !== 'boolean')
 					{
 						throw (new Error("driveList[0].status is not a boolean. driveList = " + JSON.stringify(driveList, null, '\t')));
 					}

--- a/test/test.js
+++ b/test/test.js
@@ -526,9 +526,9 @@ describe('windows-network-drive', function ()
 					{
 						throw (new Error("driveList[0].path is not a string. driveList = " + JSON.stringify(driveList, null, '\t')));
 					}
-					if (typeof firstResult.statusString !== 'string')
+					if (typeof firstResult.statusMessage !== 'string')
 					{
-						throw (new Error("driveList[0].statusString is not a string. driveList = " + JSON.stringify(driveList, null, '\t')));
+						throw (new Error("driveList[0].statusMessage is not a string. driveList = " + JSON.stringify(driveList, null, '\t')));
 					}
 
 					return;

--- a/test/test.js
+++ b/test/test.js
@@ -491,6 +491,39 @@ describe('windows-network-drive', function ()
 					{
 						throw (new Error("Could not get drive list. driveList = " + JSON.stringify(driveList, null, '\t')));
 					}
+
+
+					const driveLetters = Object.keys(driveList)
+					for (let i = 0; i < driveLetters.length; i++) {
+						/**
+						 * The drive letter should be a string of length 1, ie "Z"
+						 */
+						if ( typeof driveLetters[i] !== 'string' || driveLetters[i].length !== 1 ) {
+							throw (new Error("Drive letter is not a string of length 1. driveList = " + JSON.stringify(driveList, null, '\t')));
+						}
+						/**
+						 * The drive letter should be uppercase
+						 */
+						if ( driveLetters[i] !== driveLetters[i].toUpperCase() ) {
+							throw (new Error("Drive letter is not uppercase. driveList = " + JSON.stringify(driveList, null, '\t')));
+						}
+					}
+
+					const firstResult = driveList[driveLetters[0]];
+					if (!firstResult) {
+						throw (new Error("Bad result data. driveList = " + JSON.stringify(driveList, null, '\t')));
+					}
+
+					if (firstResult.status !== Boolean(firstResult.status)) {
+						throw (new Error("driveList[0].status is not a boolean. driveList = " + JSON.stringify(driveList, null, '\t')));
+					}
+					if (typeof firstResult.path !== 'string') {
+						throw (new Error("driveList[0].path is not a string. driveList = " + JSON.stringify(driveList, null, '\t')));
+					}
+					if (typeof firstResult.statusString !== 'string') {
+						throw (new Error("driveList[0].statusString is not a string. driveList = " + JSON.stringify(driveList, null, '\t')));
+					}
+
 					return;
 				});
 		});
@@ -593,7 +626,7 @@ describe('windows-network-drive', function ()
 						throw (new Error("Could not find mounted path " + VALID_MOUNT_PATH + "."));
 					}
 
-					if (-1 === foundDriveLetters.indexOf(driveLetter))
+					if (-1 === foundDriveLetters.findIndex(d => d.driveLetter === driveLetter))
 					{
 						throw (new Error("Should have found drive letter " + driveLetter + " in " + JSON.stringify(foundDriveLetters)));
 					}

--- a/test/test.js
+++ b/test/test.js
@@ -494,33 +494,40 @@ describe('windows-network-drive', function ()
 
 
 					const driveLetters = Object.keys(driveList)
-					for (let i = 0; i < driveLetters.length; i++) {
+					for (let i = 0; i < driveLetters.length; i++)
+					{
 						/**
 						 * The drive letter should be a string of length 1, ie "Z"
 						 */
-						if ( typeof driveLetters[i] !== 'string' || driveLetters[i].length !== 1 ) {
+						if (typeof driveLetters[i] !== 'string' || driveLetters[i].length !== 1)
+						{
 							throw (new Error("Drive letter is not a string of length 1. driveList = " + JSON.stringify(driveList, null, '\t')));
 						}
 						/**
 						 * The drive letter should be uppercase
 						 */
-						if ( driveLetters[i] !== driveLetters[i].toUpperCase() ) {
+						if (driveLetters[i] !== driveLetters[i].toUpperCase())
+						{
 							throw (new Error("Drive letter is not uppercase. driveList = " + JSON.stringify(driveList, null, '\t')));
 						}
 					}
 
 					const firstResult = driveList[driveLetters[0]];
-					if (!firstResult) {
+					if (!firstResult)
+					{
 						throw (new Error("Bad result data. driveList = " + JSON.stringify(driveList, null, '\t')));
 					}
 
-					if (firstResult.status !== Boolean(firstResult.status)) {
+					if (firstResult.status !== Boolean(firstResult.status))
+					{
 						throw (new Error("driveList[0].status is not a boolean. driveList = " + JSON.stringify(driveList, null, '\t')));
 					}
-					if (typeof firstResult.path !== 'string') {
+					if (typeof firstResult.path !== 'string')
+					{
 						throw (new Error("driveList[0].path is not a string. driveList = " + JSON.stringify(driveList, null, '\t')));
 					}
-					if (typeof firstResult.statusString !== 'string') {
+					if (typeof firstResult.statusString !== 'string')
+					{
 						throw (new Error("driveList[0].statusString is not a string. driveList = " + JSON.stringify(driveList, null, '\t')));
 					}
 


### PR DESCRIPTION
Closes #24 


This PR changes how list() fetches drives. It'll now return all drives with status info, not only the ones with OK status.

This is a **BREAKING CHANGE**:
Return type of list() has changed, from a key-value with strings to a key-value with objects containing statuses and path.
Return type of find() has changed, from a string to an object containing statuses and path.


Notes: 
* I have tested this to work locally and the unit tests pass locally
* The README mentions linting and formatting using VS Code. But no linter, linting-rules or formatting-rules are defined, so I haven't done this.