### PR TITLE
fix: fix bug when net use returns results split over multiple lines

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,6 +161,8 @@ let windowsNetworkDrive = {
 				// Status       Local     Remote                    Network
 				//
 				// -------------------------------------------------------------------------------
+				// OK           Y:        \\NETWORKA\long-long-long-long-long-name
+				//                                                 Microsoft Windows Network
 				// OK           Z:        \\NETWORKA\Files         Microsoft Windows Network
 				// The command completed successfully.
 
@@ -168,7 +170,7 @@ let windowsNetworkDrive = {
 				const lines = `${result.stdout}`
 					.replace(/^(-+)$/gm, '') // remove the "-----------------------------"-line
 					.split('\n')
-					.map((line) => line.trim()) // Trim line endings
+					.map((line) => line.replace(/[\r\n]/g, '')) // Trim line endings, but not spaces
 					.filter(Boolean) // Remove empty lines
 					.slice(1) // Remove the first line ("New connections...")
 					.slice(1) // Remove the table header line ("Status   Local...")


### PR DESCRIPTION
This PR fixes a bug that arose in [my previous PR](https://github.com/larrybahr/windows-network-drive/pull/25#discussion_r903252923).

**Current behavior:**

If `net use` returns this result (this is done on a Norwegian machine):
```
Nye tilkoblinger vil bli lagret.


Status       Lokalt    Eksternt                  Nettverk

-------------------------------------------------------------------------------
OK           U:        \\networkA\this-is-a-long-name
                                                Microsoft Windows Network
OK           V:        \\networkB\this-is-a-long-name
                                                Microsoft Windows Network
OK           Z:        \\networkC\this-is-a-long-name
                                                Microsoft Windows Network
Kommandoen er fullført.
```

`list()` returns `{}`

**New behavior:**

`list()` returns the 3 drives.